### PR TITLE
Scripts are python3 compatible

### DIFF
--- a/Fig2.py
+++ b/Fig2.py
@@ -1,9 +1,7 @@
 # Generates time-series response to a Ca pulse for each of the models. No
 # diffusion involved.
 
-import sys
 import numpy as np
-import pylab
 import matplotlib.pyplot as plt
 import moose
 import abstrModelEqns9 as ame
@@ -22,7 +20,7 @@ def singleCompt( name, params ):
     steptime = 50
 
     CaStim.expr += ' + x2 * (t > 100+' + str( runtime ) + ' ) * ( t < 100+' + str( runtime + steptime ) +  ' )'
-    print CaStim.expr
+    print( CaStim.expr )
     tab = moose.Table2( '/model/' + name + '/Atab' )
     #for i in range( 10, 19 ):
         #moose.setClock( i, 0.01 )
@@ -153,9 +151,9 @@ def runPanelDEFG( name, dist, seqDt, numSpine, seq, stimAmpl ):
         #moose.setClock( i, 0.02 )
     A = moose.vec( '/model/chem/dend/A' )
     Z = moose.vec( '/model/chem/dend/Z' )
-    print moose.element( '/model/chem/dend/A/Adot' ).expr
-    print moose.element( '/model/chem/dend/B/Bdot' ).expr
-    print moose.element( '/model/chem/dend/Ca/CaStim' ).expr
+    print(moose.element( '/model/chem/dend/A/Adot' ).expr)
+    print(moose.element( '/model/chem/dend/B/Bdot' ).expr)
+    print(moose.element( '/model/chem/dend/Ca/CaStim' ).expr)
     phase = moose.vec( '/model/chem/dend/phase' )
     ampl = moose.vec( '/model/chem/dend/ampl' )
     vel = moose.vec( '/model/chem/dend/vel' )
@@ -165,13 +163,13 @@ def runPanelDEFG( name, dist, seqDt, numSpine, seq, stimAmpl ):
     phase.nInit = 10000
     Z.nInit = 0
     for j in range( numSpine ):
-        k = blanks + j * stride
+        k = int(blanks + j * stride)
         Z[k].nInit = 1
         phase[k].nInit = preStim + seq[j] * seqDt
     moose.reinit()
     runtime = 50
     snapshot = preStim + seqDt * (numSpine - 0.8)
-    print snapshot
+    print( snapshot )
     #snapshot = 26
     moose.start( snapshot )
     avec = moose.vec( '/model/chem/dend/A' ).n

--- a/Fig5.py
+++ b/Fig5.py
@@ -112,7 +112,7 @@ def panelBCsingleCompt( fig ):
     plt.plot( t, cavec ) 
     ax = plotBoilerplate( 'C', (2,1), 'Time (s)', 'MAPK-P ($\mu$M)', xticks )
     plt.plot( t, mapkPvec ) 
-    print "Finished panelBC for single Compt dynamics"
+    print( "Finished panelBC for single Compt dynamics" )
     moose.delete( '/model' )
 
 def runStimulus( sequence ):
@@ -129,10 +129,10 @@ def runStimulus( sequence ):
         currt = clock.currentTime
         if ( t > currt ):
             moose.start( t - currt )
-            print "At t = ", t, "; assigning CaInput[", index, "] = ", conc
+            print( "At t = ", t, "; assigning CaInput[", index, "] = ", conc)
             Ca_input[ index ].concInit = conc
     moose.start(params['postStimTime'] )
-    print "Finished stimulus run at t = ", clock.currentTime
+    print( "Finished stimulus run at t = ", clock.currentTime )
 
 def runAndDisplaySumPlot( seq, label, pos, chemPlotDt ):
     runStimulus( seq )
@@ -144,7 +144,7 @@ def runAndDisplaySumPlot( seq, label, pos, chemPlotDt ):
     t = np.arange( 0, len( mapkPvec ) * chemPlotDt, chemPlotDt )
     xt = np.arange( 0, len( mapkPvec ) * chemPlotDt, 50 )
     xticks = [ str(i) for i in xt ]
-    print "XT = ", xt, xticks
+    print( "XT = ", xt, xticks )
     ax = plotBoilerplate( label, pos, 'Time (s)', 'MAPK-P ($\mu$M)', xticks )
     plt.plot( t, mapkPvec ) 
 
@@ -155,13 +155,13 @@ def runAndDisplay( seq, label, pos, chemPlotDt, maxy ):
     blanks = params['blankVoxelsAtEnd']
     step = int( round( params['seqDx'] / params['spineSpacing'] ) )
     plotIndices = [int(parentVoxel[blanks + i * step]) for i in range(len(seq)) ]
-    print plotIndices
+    print( plotIndices )
     t = np.arange( 0, len( mapk[0].vector ) * chemPlotDt, chemPlotDt )
     ax = plotBoilerplate( label, pos, 'Time (s)', 'MAPK-P ($\mu$M)')
     maxx = max( t )
     xt = np.arange( 0, maxx, 20 )
     xticks = [ str(int(i)) for i in xt ]
-    print "XT = ", xt, xticks
+    print( "XT = ", xt, xticks )
 
     ax.xaxis.set_ticks( xt )
     ax.set_xticklabels( xticks )
@@ -170,7 +170,7 @@ def runAndDisplay( seq, label, pos, chemPlotDt, maxy ):
         plt.plot( t, mapk[i].vector * 1000 )
 
 def panelEFspatialSeq( fig ):
-    print "Starting Panel EF"
+    print( "Starting Panel EF" )
     moose.seed( int(params['seed']) )
     rdes = rd.rdesigneur(
         useGssa = False,
@@ -198,10 +198,10 @@ def panelEFspatialSeq( fig ):
     setDiffConst( 'reg_phosphatase', 'diffConstPP' )
     setDiffConst( 'inact_phosphatase', 'diffConstPP' )
     moose.element( '/library/chem/dend/DEND/Ca_activate_Raf' ).Kf = params['CaActivateRafKf']
-    print "Set up rdesigneur"
+    print( "Set up rdesigneur" )
 
     rdes.buildModel()
-    print "MODEL BUILT"
+    print( "MODEL BUILT" )
 
     ################################################################
     # Run and display the stimulus

--- a/Fig6.py
+++ b/Fig6.py
@@ -42,14 +42,14 @@ def plotBoilerplate( panelTitle, plotPos, xlabel = '', ylabel = '', xticks = [] 
 
 def panelB( fig ):
     dt = 0.0001
-    npts = int(1 + 25/dt)
+    npts = int(1+25/dt)
     tab = readXplot('Fig6_data.0.1234.xplot', 'Soma_Vm.0')
     #tab = tab[:50001]
     tab = tab[:npts]
     #ax = plotBoilerplate( 'B', (0,0), ylabel = 'Vm (mV)', xticks=range(6) )
     ax = plotBoilerplate( 'B', (0,0), ylabel = 'Vm (mV)', xticks=range(0,26,5) )
     t = np.array( range( len( tab ) ) ) * dt
-    print "LEN = ", len( tab )
+    print("LEN = ", len(tab))
     plt.plot( t, tab )
     plt.xlabel( "Time (s)", fontsize = 14, horizontalalignment='left', position = (0.02,25) )
 
@@ -114,11 +114,11 @@ def panelEFGH( fig ):
             valvector.append( values[0] )
         '''
         #valmatrix.append( valvector )
-        print site, max(valvector)
+        print(site, max(valvector))
         plotMatrix( fig, site, valvector, panelTitle )
 
 def plotMatrix( fig, site, vec, panelTitle ):
-    print 'COORDS = ', 3 + site%3 , site / 3
+    print('COORDS = ', 3 + site%3 , site / 3)
     ax = plt.subplot2grid( gridShape, (3 + site%3, site/3 ) )
     d = np.array( vec )
     d.shape = (5,5)
@@ -167,11 +167,11 @@ def readXplot( fname, plotname ):
                             flag = True
                         else:
                             flag = False
-                        #print line[11:20], flag
+                        #print(line[11:20], flag)
                     if  flag and not( line[0] == '%' or line[0] == '/'):
                         tab.append( float( line[:-1] ) * 1000 )
     except IOError:
-        print "NOTAB"
+        print( "NOTAB" )
         return 0
     return tab
 
@@ -191,7 +191,7 @@ def readVm( fname ):
                     if  flag and not( line[0] == '%' or line[0] == '/'):
                         tab.append( float( line[:-1] ) * 1000 )
     except IOError:
-        print "NOTAB"
+        print("NOTAB")
         return 0
     return tab
 

--- a/Fig6_generate_data.py
+++ b/Fig6_generate_data.py
@@ -104,9 +104,9 @@ def attachStimulus( fname, rdes ):
     timeExpr = 'cos( 6.283 * t * ' + str(params['thetaFreq']/2.0) + ' )^2'
     rateExpr = str( 2.0 * params['thetaGabaSpikeRate'])
     thetaGaba.expr = str( params['baseGabaSpikeRate']) + ' + ' + rateExpr + ' * ' +  timeExpr
-    print thetaGaba.expr,
+    print(thetaGaba.expr, end=' ')
     gabar = moose.wildcardFind( '/model/elec/#/GABA' )
-    print "     NUM-GABA = ", len(gabar)
+    print("     NUM-GABA = ", len(gabar))
     rsGabar = moose.RandSpike( '/model/elec/gabaSpike', len( gabar ) )
     moose.connect( thetaGaba, 'valueOut', rsGabar, 'setRate', 'OneToAll' )
     gabaSpikes = moose.vec( '/model/elec/gabaSpike' )
@@ -146,9 +146,9 @@ def attachStimulus2( fname ):
 
 def dumpPlots( fname ):
     currt = moose.element( '/clock' ).currentTime
-    #print "os.rename( " + fname + ".xplot", fname + ".old )"
+    #print("os.rename( " + fname + ".xplot", fname + ".old )")
     os.rename( fname + ".xplot", fname + ".old" )
-    print 'Current sim time = ', currt, ", user time = ", time.time() - realStartTime
+    print('Current sim time = ', currt, ", user time = ", time.time() - realStartTime)
     sys.stdout.flush()
     fd = open( fname + ".xplot", "w" )
     for ii in params:
@@ -213,14 +213,14 @@ def printStuff( sequence, firstSpineOnCompt, rdes ):
             #headCa = moose.element( headPath + '/Ca_conc' )
             #headGlu = moose.element( headPath + '/glu' )
             #headNmda = moose.element( headPath + '/NMDA' )
-            print i, j, spikeIdx, head.name, rdes.elecid.parentCompartmentOfSpine[head].name
+            print( i, j, spikeIdx, head.name, rdes.elecid.parentCompartmentOfSpine[head].name)
 
 def main():
     global rdes
     global params
     sequence = [0,1,2,3,4]
 
-    #print params['sequence'], sequence
+    #print(params['sequence'], sequence)
     for ii in range( len( sys.argv ) ):
         if sys.argv[ii][:2] == '--':
             argName = sys.argv[ii][2:]
@@ -243,7 +243,7 @@ def main():
 
     sequence = convertSeq( params['sequence'] )
     fname = baseFname + '.' +  str( int( params['fnumber'] ) ) + '.' + str( int( params['sequence'] ) )
-    print params['sequence'], sequence, fname
+    print(params['sequence'], sequence, fname)
 
     diffusionLength = params['diffusionLength']
     dendLength = params['dendLength']
@@ -399,7 +399,7 @@ def main():
     rdes.buildModel()
     #moose.showfields( '/model/chem/dend/DEND/PKA/KA' )
     #moose.le( '/model/elec' )
-    #print "NUM PLOTS = ", len( rdes.plotNames)
+    #print("NUM PLOTS = ", len( rdes.plotNames))
     firstSpineOnCompt = attachStimulus( fname, rdes )
 
     fd = open( fname + ".xplot", "w" )
@@ -412,12 +412,12 @@ def main():
     periodicOutput = moose.PyRun( '/model/graphs/periodicOutput' )
     periodicOutput.tick = 19
     periodicOutput.runString = 'dumpPlots( "' + fname + '" )'
-    periodicOutput.initString = 'print "Starting PeriodicOutput"'
+    periodicOutput.initString = 'print("Starting PeriodicOutput")'
 
     spatOutput = moose.PyRun( '/model/graphs/spatOutput' )
     spatOutput.tick = 18
     spatOutput.runString = 'dumpSpatialPlots( "' + fname + '" )'
-    spatOutput.initString = 'print "Starting Spatial Output"'
+    spatOutput.initString = 'print("Starting Spatial Output")'
     moose.reinit()
     moose.seed( 1 )
 
@@ -432,8 +432,8 @@ def main():
     '''
     ni = len( spikes ) / 8.0
     spikeStartIndices = [ int( (i + 0.5) * ni ) for i in range( 8 ) ]
-    print "########## len(spikes) = ", len(spikes)
-    print "########## spikeStartIndices = ", spikeStartIndices
+    print("########## len(spikes) = ", len(spikes))
+    print("########## spikeStartIndices = ", spikeStartIndices)
     '''
 
     stimIntervalTime = params['seqDt'] - params['stimBurstTime']

--- a/abstrModelEqns9.py
+++ b/abstrModelEqns9.py
@@ -6,7 +6,6 @@ import moose
 # Bdot = k1b.A - k2b.B
 #
 
-
 def parseExpr( expr, params, hasCa ):
     if hasCa:
         expr = expr.replace( 'Ca', 'x0' )
@@ -56,9 +55,9 @@ def makeChemProto( name, Aexpr, Bexpr, params ):
     Bdot.expr = parseExpr( Bexpr, params, False )
     CaStim.expr = 'x2 * exp( -((x0 - t)^2)/(2* ' + str(sw*sw) + ') )'
 
-    #print Adot.expr
-    #print Bdot.expr
-    #print CaStim.expr
+    #print(Adot.expr)
+    #print(Bdot.expr)
+    #print(CaStim.expr)
 
     # Connections
     Adot.x.num = 4
@@ -71,7 +70,7 @@ def makeChemProto( name, Aexpr, Bexpr, params ):
     Bdot.x.num = 3
     if name[:5] == 'negFF':
         moose.connect( Ca, 'nOut', Bdot.x[0], 'input' )
-        print 'Doing special msg'
+        print('Doing special msg')
     else:
         moose.connect( A, 'nOut', Bdot.x[0], 'input' )
     moose.connect( B, 'nOut', Bdot.x[1], 'input' )
@@ -227,13 +226,13 @@ def makeNegFF( args ):
 
 if __name__ == '__main__':
     moose.Neutral( '/library' )
-    print "Making Bistable model"
+    print("Making Bistable model")
     makeBis()
-    print "Making FHN model"
+    print("Making FHN model")
     makeFHN()
-    print "Making Negative Feedback model"
+    print("Making Negative Feedback model")
     makeNegFB()
-    print "Making Negative Feedforward models"
+    print("Making Negative Feedforward models")
     makeNegFF()
 
 

--- a/proto21.py
+++ b/proto21.py
@@ -4,7 +4,7 @@
 #** The 1991 Traub set of voltage and concentration dependent channels
 #** Implemented as tabchannels by : Dave Beeman
 #**      R.D.Traub, R. K. S. Wong, R. Miles, and H. Michelson
-#**	Journal of Neurophysiology, Vol. 66, p. 635 (1991)
+#**    Journal of Neurophysiology, Vol. 66, p. 635 (1991)
 #**
 #** This file depends on functions and constants defined in defaults.g
 #** As it is also intended as an example of the use of the tabchannel
@@ -59,62 +59,62 @@ CA_SCALE = 25000        # Ratio of Traub units to mM. 250::0.01
 #//========================================================================
 
 def make_Ca( name ):
-	if moose.exists( '/library/' + name):
-		return
-	Ca = moose.HHChannel( '/library/' + name )
-	Ca.Ek = ECA
-	Ca.Gbar = 40 * SOMA_A
-	Ca.Gk = 0
-	Ca.Xpower = 2
-	Ca.Ypower = 1
-	Ca.Zpower = 0
+    if moose.exists( '/library/' + name):
+        return
+    Ca = moose.HHChannel( '/library/' + name )
+    Ca.Ek = ECA
+    Ca.Gbar = 40 * SOMA_A
+    Ca.Gk = 0
+    Ca.Xpower = 2
+    Ca.Ypower = 1
+    Ca.Zpower = 0
 
-	xgate = moose.element( Ca.path + '/gateX' )
-	xA = np.array( [ 1.6e3, 0, 1.0, -1.0 * (0.065 + EREST_ACT), -0.01389, -20e3 * (0.0511 + EREST_ACT), 20e3, -1.0, -1.0 * (0.0511 + EREST_ACT), 5.0e-3, 3000, -0.1, 0.05 ] )
-#	xgate.min = -0.1
-#	xgate.max = 0.05
-#	xgate.divs = 3000
+    xgate = moose.element( Ca.path + '/gateX' )
+    xA = np.array( [ 1.6e3, 0, 1.0, -1.0 * (0.065 + EREST_ACT), -0.01389, -20e3 * (0.0511 + EREST_ACT), 20e3, -1.0, -1.0 * (0.0511 + EREST_ACT), 5.0e-3, 3000, -0.1, 0.05 ] )
+#    xgate.min = -0.1
+#    xgate.max = 0.05
+#    xgate.divs = 3000
 #// Converting Traub's expressions for the gCa/s alpha and beta functions
 #// to SI units and entering the A, B, C, D and F parameters, we get:
-#	xgate.alpha( 1.6e3, 0, 1.0, -1.0 * (0.065 + EREST_ACT), -0.01389 )
-#	xgate.beta( -20e3 * (0.0511 + EREST_ACT), 20e3, -1.0, -1.0 * (0.0511 + EREST_ACT), 5.0e-3 )
-	#xgate.setupAlpha( xA )
-	xgate.alphaParms = xA
+#    xgate.alpha( 1.6e3, 0, 1.0, -1.0 * (0.065 + EREST_ACT), -0.01389 )
+#    xgate.beta( -20e3 * (0.0511 + EREST_ACT), 20e3, -1.0, -1.0 * (0.0511 + EREST_ACT), 5.0e-3 )
+    #xgate.setupAlpha( xA )
+    xgate.alphaParms = xA
 
 
 #  The Y gate (gCa/r) is not quite of this form.  For V > EREST_ACT, alpha =
 #  5*{exp({-50*(V - EREST_ACT)})}.  Otherwise, alpha = 5.  Over the entire
 #  range, alpha + beta = 5.  To create the Y_A and Y_B tables, we use some
 #  of the pieces of the setupalpha function.
-	ygate = moose.element( Ca.path + '/gateY' )
-	ygate.min = -0.1
-	ygate.max = 0.05
-	ygate.divs = 3000
-	yA = np.zeros( (ygate.divs + 1), dtype=float)
-	yB = np.zeros( (ygate.divs + 1), dtype=float)
+    ygate = moose.element( Ca.path + '/gateY' )
+    ygate.min = -0.1
+    ygate.max = 0.05
+    ygate.divs = 3000
+    yA = np.zeros( (ygate.divs + 1), dtype=float)
+    yB = np.zeros( (ygate.divs + 1), dtype=float)
 
 
 #Fill the Y_A table with alpha values and the Y_B table with (alpha+beta)
-	dx = (ygate.max - ygate.min)/ygate.divs
-	x = ygate.min
-	for i in range( ygate.divs + 1 ):
-		if ( x > EREST_ACT):
-			yA[i] = 5.0 * math.exp( -50 * (x - EREST_ACT) )
-		else:
-			yA[i] = 0.0
-		#yB[i] = 6.0 - yA[i]
-		yB[i] = 5.0
-		x += dx
-	ygate.tableA = yA
-	ygate.tableB = yB
+    dx = (ygate.max - ygate.min)/ygate.divs
+    x = ygate.min
+    for i in range( ygate.divs + 1 ):
+        if ( x > EREST_ACT):
+            yA[i] = 5.0 * math.exp( -50 * (x - EREST_ACT) )
+        else:
+            yA[i] = 0.0
+        #yB[i] = 6.0 - yA[i]
+        yB[i] = 5.0
+        x += dx
+    ygate.tableA = yA
+    ygate.tableB = yB
 # Tell the cell reader that the current from this channel must be fed into
 # the Ca_conc pool of calcium.
-	addmsg1 = moose.Mstring( Ca.path + '/addmsg1' )
-	addmsg1.value = '.	IkOut	../Ca_conc	current'
+    addmsg1 = moose.Mstring( Ca.path + '/addmsg1' )
+    addmsg1.value = '.    IkOut    ../Ca_conc    current'
 # in some compartments, whe have an NMDA_Ca_conc object to put the current
 # into.
-	addmsg2 = moose.Mstring( Ca.path + '/addmsg2' )
-	addmsg2.value = '.	IkOut	../NMDA_Ca_conc	current'
+    addmsg2 = moose.Mstring( Ca.path + '/addmsg2' )
+    addmsg2.value = '.    IkOut    ../NMDA_Ca_conc    current'
 # As we typically use the cell reader to create copies of these prototype
 #elements in one or more compartments, we need some way to be sure that the
 #needed messages are established.  Although the cell reader has enough
@@ -161,13 +161,13 @@ def make_Ca( name ):
 #//========================================================================
 
 def make_Ca_conc( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	conc = moose.CaConc( '/library/tempName' )
-        conc.name = name
-	conc.tau = 0.013333  # sec
-	conc.B  = 17.402e12 # Curr to conc conversion for soma
-	conc.Ca_base = 0.00000
+    if moose.exists( '/library/' + name ):
+        return
+    conc = moose.CaConc( '/library/tempName' )
+    conc.name = name
+    conc.tau = 0.013333  # sec
+    conc.B  = 17.402e12 # Curr to conc conversion for soma
+    conc.Ca_base = 0.00000
 
 #This Ca_concen element should receive a message from any calcium channels
 # with the current going through the channel. Here we have this specified
@@ -185,34 +185,34 @@ def make_Ca_conc( name ):
 #  functions of concentration, instead of voltage.
 
 def make_K_AHP( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	K_AHP = moose.HHChannel( '/library/' + name )
-	K_AHP.Ek = EK	#			V
-	K_AHP.Gbar = 8 * SOMA_A #	S
-	K_AHP.Gk = 0	#	S
-	K_AHP.Xpower = 0
-	K_AHP.Ypower = 0
-	K_AHP.Zpower = 1
+    if moose.exists( '/library/' + name ):
+        return
+    K_AHP = moose.HHChannel( '/library/' + name )
+    K_AHP.Ek = EK    #            V
+    K_AHP.Gbar = 8 * SOMA_A #    S
+    K_AHP.Gk = 0    #    S
+    K_AHP.Xpower = 0
+    K_AHP.Ypower = 0
+    K_AHP.Zpower = 1
 
-	zgate = moose.element( K_AHP.path + '/gateZ' )
-	xmax = 500.0
-	zgate.min = 0
-	zgate.max = xmax
-	zgate.divs = 3000
-	zA = np.zeros( (zgate.divs + 1), dtype=float)
-	zB = np.zeros( (zgate.divs + 1), dtype=float)
-	dx = (zgate.max - zgate.min)/zgate.divs
-	x = zgate.min
-	for i in range( zgate.divs + 1 ):
+    zgate = moose.element( K_AHP.path + '/gateZ' )
+    xmax = 500.0
+    zgate.min = 0
+    zgate.max = xmax
+    zgate.divs = 3000
+    zA = np.zeros( (zgate.divs + 1), dtype=float)
+    zB = np.zeros( (zgate.divs + 1), dtype=float)
+    dx = (zgate.max - zgate.min)/zgate.divs
+    x = zgate.min
+    for i in range( zgate.divs + 1 ):
             zA[i] = min( 0.02 * CA_SCALE * x, 10 )
             zB[i] = 1.0
             x = x + dx
 
-	zgate.tableA = zA
-	zgate.tableB = zB
-	addmsg1 = moose.Mstring( K_AHP.path + '/addmsg1' )
-	addmsg1.value = '../Ca_conc	concOut	. concen'
+    zgate.tableA = zA
+    zgate.tableB = zB
+    addmsg1 = moose.Mstring( K_AHP.path + '/addmsg1' )
+    addmsg1.value = '../Ca_conc    concOut    . concen'
 # Use an added field to tell the cell reader to set up a message from the
 # Ca_Conc with concentration info, to the current K_AHP object.
 
@@ -233,69 +233,69 @@ def make_K_AHP( name ):
 #the multiplicative Ca-dependent factor in the conductance.
 
 def make_K_C( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	K_C = moose.HHChannel( '/library/' + name )
-	K_C.Ek = EK					#	V
-	K_C.Gbar = 100.0 * SOMA_A 	#	S
-	K_C.Gk = 0					#	S
-	K_C.Xpower = 1
-	K_C.Zpower = 1
-	K_C.instant = 4				# Flag: 0x100 means Z gate is instant.
-        K_C.useConcentration = 1
+    if moose.exists( '/library/' + name ):
+        return
+    K_C = moose.HHChannel( '/library/' + name )
+    K_C.Ek = EK                    #    V
+    K_C.Gbar = 100.0 * SOMA_A     #    S
+    K_C.Gk = 0                    #    S
+    K_C.Xpower = 1
+    K_C.Zpower = 1
+    K_C.instant = 4                # Flag: 0x100 means Z gate is instant.
+    K_C.useConcentration = 1
 
-	# Now make a X-table for the voltage-dependent activation parameter.
-	xgate = moose.element( K_C.path + '/gateX' )
-	xgate.min = -0.1
-	xgate.max = 0.05
-	xgate.divs = 3000
-	xA = np.zeros( (xgate.divs + 1), dtype=float)
-	xB = np.zeros( (xgate.divs + 1), dtype=float)
-	dx = (xgate.max - xgate.min)/xgate.divs
-	x = xgate.min
-	for i in range( xgate.divs + 1 ):
-		alpha = 0.0
-		beta = 0.0
-		if (x < EREST_ACT + 0.05):
-			alpha = math.exp( 53.872 * (x - EREST_ACT) - 0.66835 ) / 0.018975
-			beta = 2000* (math.exp ( (EREST_ACT + 0.0065 - x)/0.027)) - alpha
-		else:
-			alpha = 2000 * math.exp( ( EREST_ACT + 0.0065 - x)/0.027 )
-			beta = 0.0
-		xA[i] = alpha
-		xB[i] = alpha + beta
-		x = x + dx
-	xgate.tableA = xA
-	xgate.tableB = xB
+    # Now make a X-table for the voltage-dependent activation parameter.
+    xgate = moose.element( K_C.path + '/gateX' )
+    xgate.min = -0.1
+    xgate.max = 0.05
+    xgate.divs = 3000
+    xA = np.zeros( (xgate.divs + 1), dtype=float)
+    xB = np.zeros( (xgate.divs + 1), dtype=float)
+    dx = (xgate.max - xgate.min)/xgate.divs
+    x = xgate.min
+    for i in range( xgate.divs + 1 ):
+        alpha = 0.0
+        beta = 0.0
+        if (x < EREST_ACT + 0.05):
+            alpha = math.exp( 53.872 * (x - EREST_ACT) - 0.66835 ) / 0.018975
+            beta = 2000* (math.exp ( (EREST_ACT + 0.0065 - x)/0.027)) - alpha
+        else:
+            alpha = 2000 * math.exp( ( EREST_ACT + 0.0065 - x)/0.027 )
+            beta = 0.0
+        xA[i] = alpha
+        xB[i] = alpha + beta
+        x = x + dx
+    xgate.tableA = xA
+    xgate.tableB = xB
 
 # Create a table for the function of concentration, allowing a
 # concentration range of 0 to 200, with 3000 divisions.  This is done
 # using the Z gate, which can receive a CONCEN message.  By using
 # the "instant" flag, the A and B tables are evaluated as lookup tables,
 #  rather than being used in a differential equation.
-	zgate = moose.element( K_C.path + '/gateZ' )
-	zgate.min = 0.0
-	xmax = 150.0
-	zgate.max = xmax
-	zgate.divs = 3000
-	zA = np.zeros( (zgate.divs + 1), dtype=float)
-	zB = np.zeros( (zgate.divs + 1), dtype=float)
-	dx = ( zgate.max -  zgate.min)/ zgate.divs
-	x = zgate.min
-	#CaScale = 100000.0 / 250.0e-3
-	for i in range( zgate.divs + 1 ):
-		zA[i] = min( 1000.0, x * CA_SCALE / (250 * xmax ) )
-		zB[i] = 1000.0
-		x += dx
-	zgate.tableA = zA
-	zgate.tableB = zB
+    zgate = moose.element( K_C.path + '/gateZ' )
+    zgate.min = 0.0
+    xmax = 150.0
+    zgate.max = xmax
+    zgate.divs = 3000
+    zA = np.zeros( (zgate.divs + 1), dtype=float)
+    zB = np.zeros( (zgate.divs + 1), dtype=float)
+    dx = ( zgate.max -  zgate.min)/ zgate.divs
+    x = zgate.min
+    #CaScale = 100000.0 / 250.0e-3
+    for i in range( zgate.divs + 1 ):
+        zA[i] = min( 1000.0, x * CA_SCALE / (250 * xmax ) )
+        zB[i] = 1000.0
+        x += dx
+    zgate.tableA = zA
+    zgate.tableB = zB
 
 # Now we need to provide for messages that link to external elements.
 # The message that sends the Ca concentration to the Z gate tables is stored
 # in an added field of the channel, so that it may be found by the cell
 # reader.
-	addmsg1 = moose.Mstring( K_C.path + '/addmsg1' )
-	addmsg1.value = '../Ca_conc	concOut	. concen'
+    addmsg1 = moose.Mstring( K_C.path + '/addmsg1' )
+    addmsg1.value = '../Ca_conc    concOut    . concen'
 
 
 # The remaining channels are straightforward tabchannel implementations
@@ -304,156 +304,155 @@ def make_K_C( name ):
 #/                Tabchannel Na Hippocampal cell channel
 #/========================================================================
 def make_Na( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	Na = moose.HHChannel( '/library/' + name )
-	Na.Ek = ENA				#	V
-	Na.Gbar = 300 * SOMA_A	#	S
-	Na.Gk = 0				#	S
-	Na.Xpower = 2
-	Na.Ypower = 1
-	Na.Zpower = 0
+    if moose.exists( '/library/' + name ):
+        return
+    Na = moose.HHChannel( '/library/' + name )
+    Na.Ek = ENA                #    V
+    Na.Gbar = 300 * SOMA_A    #    S
+    Na.Gk = 0                #    S
+    Na.Xpower = 2
+    Na.Ypower = 1
+    Na.Zpower = 0
 
-	xgate = moose.element( Na.path + '/gateX' )
-	xA = np.array( [ 320e3 * (0.0131 + EREST_ACT),
-		-320e3, -1.0, -1.0 * (0.0131 + EREST_ACT), -0.004, 
-		-280e3 * (0.0401 + EREST_ACT), 280e3, -1.0, 
-		-1.0 * (0.0401 + EREST_ACT), 5.0e-3, 
-		3000, -0.1, 0.05 ] )
-	xgate.alphaParms = xA
+    xgate = moose.element( Na.path + '/gateX' )
+    xA = np.array( [ 320e3 * (0.0131 + EREST_ACT),
+        -320e3, -1.0, -1.0 * (0.0131 + EREST_ACT), -0.004, 
+        -280e3 * (0.0401 + EREST_ACT), 280e3, -1.0, 
+        -1.0 * (0.0401 + EREST_ACT), 5.0e-3, 
+        3000, -0.1, 0.05 ] )
+    xgate.alphaParms = xA
 
 
-	#xgate.alpha( 320e3 * (0.0131 + EREST_ACT), -320e3, -1.0, -1.0 * (0.0131 + EREST_ACT), -0.004 )
-	#xgate.beta( -280e3 * (0.0401 + EREST_ACT), 280e3, -1.0, -1.0 * (0.0401 + EREST_ACT), 5.0e-3 )
+    #xgate.alpha( 320e3 * (0.0131 + EREST_ACT), -320e3, -1.0, -1.0 * (0.0131 + EREST_ACT), -0.004 )
+    #xgate.beta( -280e3 * (0.0401 + EREST_ACT), 280e3, -1.0, -1.0 * (0.0401 + EREST_ACT), 5.0e-3 )
 
-	ygate = moose.element( Na.path + '/gateY' )
-	yA = np.array( [ 128.0, 0.0, 0.0, -1.0 * (0.017 + EREST_ACT), 0.018,
-		4.0e3, 0.0, 1.0, -1.0 * (0.040 + EREST_ACT), -5.0e-3, 
-		3000, -0.1, 0.05 ] )
-	ygate.alphaParms = yA
+    ygate = moose.element( Na.path + '/gateY' )
+    yA = np.array( [ 128.0, 0.0, 0.0, -1.0 * (0.017 + EREST_ACT), 0.018,
+        4.0e3, 0.0, 1.0, -1.0 * (0.040 + EREST_ACT), -5.0e-3, 
+        3000, -0.1, 0.05 ] )
+    ygate.alphaParms = yA
 
-	#ygate.alpha( 128.0, 0.0, 0.0, -1.0 * (0.017 + EREST_ACT), 0.018 )
-	#ygate.beta( 4.0e3, 0.0, 1.0, -1.0 * (0.040 + EREST_ACT), -5.0e-3 )
+    #ygate.alpha( 128.0, 0.0, 0.0, -1.0 * (0.017 + EREST_ACT), 0.018 )
+    #ygate.beta( 4.0e3, 0.0, 1.0, -1.0 * (0.040 + EREST_ACT), -5.0e-3 )
 
 #========================================================================
 #                Tabchannel K(DR) Hippocampal cell channel
 #========================================================================
 def make_K_DR( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	K_DR = moose.HHChannel( '/library/' + name )
-	K_DR.Ek = EK				#	V
-	K_DR.Gbar = 150 * SOMA_A	#	S
-	K_DR.Gk = 0				#	S
-	K_DR.Xpower = 1
-	K_DR.Ypower = 0
-	K_DR.Zpower = 0
+    if moose.exists( '/library/' + name ):
+        return
+    K_DR = moose.HHChannel( '/library/' + name )
+    K_DR.Ek = EK                #    V
+    K_DR.Gbar = 150 * SOMA_A    #    S
+    K_DR.Gk = 0                #    S
+    K_DR.Xpower = 1
+    K_DR.Ypower = 0
+    K_DR.Zpower = 0
 
-	xgate = moose.element( K_DR.path + '/gateX' )
-	xA = np.array( [ 16e3 * (0.0351 + EREST_ACT), 
-		-16e3, -1.0, -1.0 * (0.0351 + EREST_ACT), -0.005,
-		250, 0.0, 0.0, -1.0 * (0.02 + EREST_ACT), 0.04,
-		3000, -0.1, 0.05 ] )
-	xgate.alphaParms = xA
-	#xgate.alpha( 16e3 * (0.0351 + EREST_ACT), -16e3, -1.0, -1.0 * (0.0351 + EREST_ACT), -0.005 )
-	#xgate.beta( 250, 0.0, 0.0, -1.0 * (0.02 + EREST_ACT), 0.04 )
+    xgate = moose.element( K_DR.path + '/gateX' )
+    xA = np.array( [ 16e3 * (0.0351 + EREST_ACT), 
+        -16e3, -1.0, -1.0 * (0.0351 + EREST_ACT), -0.005,
+        250, 0.0, 0.0, -1.0 * (0.02 + EREST_ACT), 0.04,
+        3000, -0.1, 0.05 ] )
+    xgate.alphaParms = xA
+    #xgate.alpha( 16e3 * (0.0351 + EREST_ACT), -16e3, -1.0, -1.0 * (0.0351 + EREST_ACT), -0.005 )
+    #xgate.beta( 250, 0.0, 0.0, -1.0 * (0.02 + EREST_ACT), 0.04 )
 
 #========================================================================
 #                Tabchannel K(A) Hippocampal cell channel
 #========================================================================
 def make_K_A( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	K_A = moose.HHChannel( '/library/' + name )
-	K_A.Ek = EK				#	V
-	K_A.Gbar = 50 * SOMA_A	#	S
-	K_A.Gk = 0				#	S
-	K_A.Xpower = 1
-	K_A.Ypower = 1
-	K_A.Zpower = 0
+    if moose.exists( '/library/' + name ):
+        return
+    K_A = moose.HHChannel( '/library/' + name )
+    K_A.Ek = EK                #    V
+    K_A.Gbar = 50 * SOMA_A    #    S
+    K_A.Gk = 0                #    S
+    K_A.Xpower = 1
+    K_A.Ypower = 1
+    K_A.Zpower = 0
 
-	xgate = moose.element( K_A.path + '/gateX' )
-	xA = np.array( [ 20e3 * (0.0131 + EREST_ACT), 
-		-20e3, -1.0, -1.0 * (0.0131 + EREST_ACT), -0.01,
-		-17.5e3 * (0.0401 + EREST_ACT), 
-		17.5e3, -1.0, -1.0 * (0.0401 + EREST_ACT), 0.01,
-		3000, -0.1, 0.05 ] )
-	xgate.alphaParms = xA
-	# xgate.alpha( 20e3 * (0.0131 + EREST_ACT), -20e3, -1.0, -1.0 * (0.0131 + EREST_ACT), -0.01 )
-	# xgate.beta( -17.5e3 * (0.0401 + EREST_ACT), 17.5e3, -1.0, -1.0 * (0.0401 + EREST_ACT), 0.01 )
+    xgate = moose.element( K_A.path + '/gateX' )
+    xA = np.array( [ 20e3 * (0.0131 + EREST_ACT), 
+        -20e3, -1.0, -1.0 * (0.0131 + EREST_ACT), -0.01,
+        -17.5e3 * (0.0401 + EREST_ACT), 
+        17.5e3, -1.0, -1.0 * (0.0401 + EREST_ACT), 0.01,
+        3000, -0.1, 0.05 ] )
+    xgate.alphaParms = xA
+    # xgate.alpha( 20e3 * (0.0131 + EREST_ACT), -20e3, -1.0, -1.0 * (0.0131 + EREST_ACT), -0.01 )
+    # xgate.beta( -17.5e3 * (0.0401 + EREST_ACT), 17.5e3, -1.0, -1.0 * (0.0401 + EREST_ACT), 0.01 )
 
-	ygate = moose.element( K_A.path + '/gateY' )
-	yA = np.array( [ 1.6, 0.0, 0.0, 0.013 - EREST_ACT, 0.018,
-		50.0, 0.0, 1.0, -1.0 * (0.0101 + EREST_ACT), -0.005,
-		3000, -0.1, 0.05 ] )
-	ygate.alphaParms = yA
-	# ygate.alpha( 1.6, 0.0, 0.0, 0.013 - EREST_ACT, 0.018 )
-	# ygate.beta( 50.0, 0.0, 1.0, -1.0 * (0.0101 + EREST_ACT), -0.005 )
+    ygate = moose.element( K_A.path + '/gateY' )
+    yA = np.array( [ 1.6, 0.0, 0.0, 0.013 - EREST_ACT, 0.018,
+        50.0, 0.0, 1.0, -1.0 * (0.0101 + EREST_ACT), -0.005,
+        3000, -0.1, 0.05 ] )
+    ygate.alphaParms = yA
+    # ygate.alpha( 1.6, 0.0, 0.0, 0.013 - EREST_ACT, 0.018 )
+    # ygate.beta( 50.0, 0.0, 1.0, -1.0 * (0.0101 + EREST_ACT), -0.005 )
 #========================================================================
 #                SynChan: Glu receptor
 #========================================================================
 
 def make_glu( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	glu = moose.SynChan( '/library/' + name )
-	glu.Ek = 0.0
-	glu.tau1 = 2.0e-3
-	glu.tau2 = 9.0e-3
-	glu.Gbar = 40 * SOMA_A
-        sh = moose.SimpleSynHandler( glu.path + '/sh' )
-        moose.connect( sh, 'activationOut', glu, 'activation' )
-        sh.numSynapses = 1
-        sh.synapse[0].weight = 1
+    if moose.exists( '/library/' + name ):
+        return
+    glu = moose.SynChan( '/library/' + name )
+    glu.Ek = 0.0
+    glu.tau1 = 2.0e-3
+    glu.tau2 = 9.0e-3
+    glu.Gbar = 40 * SOMA_A
+    sh = moose.SimpleSynHandler( glu.path + '/sh' )
+    moose.connect( sh, 'activationOut', glu, 'activation' )
+    sh.numSynapses = 1
+    sh.synapse[0].weight = 1
 #========================================================================
 #                SynChan: Glu receptor
 #========================================================================
 
 def make_GABA( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	GABA = moose.SynChan( '/library/' + name )
-	GABA.Ek = EK + 10.0e-3
-	GABA.tau1 = 4.0e-3
-	GABA.tau2 = 9.0e-3
-	GABA.Gbar = 40 * SOMA_A
-        sh = moose.SimpleSynHandler( GABA.path + '/sh' )
-        moose.connect( sh, 'activationOut', GABA, 'activation' )
-        sh.numSynapses = 1
-        sh.synapse[0].weight = 1
-
+    if moose.exists( '/library/' + name ):
+        return
+    GABA = moose.SynChan( '/library/' + name )
+    GABA.Ek = EK + 10.0e-3
+    GABA.tau1 = 4.0e-3
+    GABA.tau2 = 9.0e-3
+    GABA.Gbar = 40 * SOMA_A
+    sh = moose.SimpleSynHandler( GABA.path + '/sh' )
+    moose.connect( sh, 'activationOut', GABA, 'activation' )
+    sh.numSynapses = 1
+    sh.synapse[0].weight = 1
 
 #========================================================================
 #                SynChan: NMDA receptor
 #========================================================================
 
 def make_NMDA( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	NMDA = moose.NMDAChan( '/library/' + name )
-	NMDA.Ek = 0.0
-	NMDA.tau1 = 20.0e-3
-	NMDA.tau2 = 20.0e-3
-	NMDA.Gbar = 5 * SOMA_A
-	NMDA.CMg = 1.2		#	[Mg]ext in mM
-	NMDA.KMg_A = 1.0/0.28
-	NMDA.KMg_B = 1.0/62
-        NMDA.temperature = 300  # Temperature in Kelvin.
-        NMDA.extCa = 1.5        # [Ca]ext in mM
-        NMDA.intCa = 0.00008        # [Ca]int in mM
-        NMDA.intCaScale = 1         # Scale factor from elec Ca units to mM
-        NMDA.intCaOffset = 0.00008  # Basal [Ca]int in mM
-        NMDA.condFraction = 0.02  # Fraction of conductance due to Ca
+    if moose.exists( '/library/' + name ):
+        return
+    NMDA = moose.NMDAChan( '/library/' + name )
+    NMDA.Ek = 0.0
+    NMDA.tau1 = 20.0e-3
+    NMDA.tau2 = 20.0e-3
+    NMDA.Gbar = 5 * SOMA_A
+    NMDA.CMg = 1.2        #    [Mg]ext in mM
+    NMDA.KMg_A = 1.0/0.28
+    NMDA.KMg_B = 1.0/62
+    NMDA.temperature = 300  # Temperature in Kelvin.
+    NMDA.extCa = 1.5        # [Ca]ext in mM
+    NMDA.intCa = 0.00008        # [Ca]int in mM
+    NMDA.intCaScale = 1         # Scale factor from elec Ca units to mM
+    NMDA.intCaOffset = 0.00008  # Basal [Ca]int in mM
+    NMDA.condFraction = 0.02  # Fraction of conductance due to Ca
 
-	addmsg1 = moose.Mstring( NMDA.path + '/addmsg1' )
-	addmsg1.value = '.	ICaOut ../Ca_conc current'
-	addmsg2 = moose.Mstring( NMDA.path + '/addmsg2' )
-	addmsg2.value = '../Ca_conc	concOut . assignIntCa'
+    addmsg1 = moose.Mstring( NMDA.path + '/addmsg1' )
+    addmsg1.value = '.    ICaOut ../Ca_conc current'
+    addmsg2 = moose.Mstring( NMDA.path + '/addmsg2' )
+    addmsg2.value = '../Ca_conc    concOut . assignIntCa'
 
-	sh = moose.SimpleSynHandler( NMDA.path + '/sh' )
-	moose.connect( sh, 'activationOut', NMDA, 'activation' )
-	sh.numSynapses = 1
-	sh.synapse[0].weight = 1
+    sh = moose.SimpleSynHandler( NMDA.path + '/sh' )
+    moose.connect( sh, 'activationOut', NMDA, 'activation' )
+    sh.numSynapses = 1
+    sh.synapse[0].weight = 1
 
 #========================================================================
 # The Ca_NMDA channel is a subset of the NMDA channel that carries Ca.
@@ -468,62 +467,62 @@ def make_NMDA( name ):
 #========================================================================
 
 def make_Ca_NMDA( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	Ca_NMDA = moose.NMDAChan( '/library/' + name )
-	Ca_NMDA.Ek = 0.0
-	Ca_NMDA.tau1 = 20.0e-3
-	Ca_NMDA.tau2 = 20.0e-3
-	Ca_NMDA.Gbar = 5 * SOMA_A
-	Ca_NMDA.CMg = 1.2		#	[Mg]ext in mM
-	Ca_NMDA.KMg_A = 1.0/0.28
-	Ca_NMDA.KMg_B = 1.0/62
-        Ca_NMDA.temperature = 300  # Temperature in Kelvin.
-        Ca_NMDA.extCa = 1.5        # [Ca]ext in mM
-        Ca_NMDA.intCa = 0.00008        # [Ca]int in mM
-        Ca_NMDA.intCaScale = 1         # Scale factor from elec Ca units to mM
-        Ca_NMDA.intCaOffset = 0.00008  # Basal [Ca]int in mM
-        Ca_NMDA.condFraction = 0.02  # Fraction of conductance due to Ca
+    if moose.exists( '/library/' + name ):
+        return
+    Ca_NMDA = moose.NMDAChan( '/library/' + name )
+    Ca_NMDA.Ek = 0.0
+    Ca_NMDA.tau1 = 20.0e-3
+    Ca_NMDA.tau2 = 20.0e-3
+    Ca_NMDA.Gbar = 5 * SOMA_A
+    Ca_NMDA.CMg = 1.2        #    [Mg]ext in mM
+    Ca_NMDA.KMg_A = 1.0/0.28
+    Ca_NMDA.KMg_B = 1.0/62
+    Ca_NMDA.temperature = 300  # Temperature in Kelvin.
+    Ca_NMDA.extCa = 1.5        # [Ca]ext in mM
+    Ca_NMDA.intCa = 0.00008        # [Ca]int in mM
+    Ca_NMDA.intCaScale = 1         # Scale factor from elec Ca units to mM
+    Ca_NMDA.intCaOffset = 0.00008  # Basal [Ca]int in mM
+    Ca_NMDA.condFraction = 0.02  # Fraction of conductance due to Ca
 
-	addmsg1 = moose.Mstring( Ca_NMDA.path + '/addmsg1' )
-	addmsg1.value = '.	ICaOut ../Ca_conc current'
-	addmsg2 = moose.Mstring( Ca_NMDA.path + '/addmsg2' )
-	addmsg2.value = '../Ca_conc	concOut . assignIntCa'
+    addmsg1 = moose.Mstring( Ca_NMDA.path + '/addmsg1' )
+    addmsg1.value = '.    ICaOut ../Ca_conc current'
+    addmsg2 = moose.Mstring( Ca_NMDA.path + '/addmsg2' )
+    addmsg2.value = '../Ca_conc    concOut . assignIntCa'
 
-	sh = moose.SimpleSynHandler( Ca_NMDA.path + '/sh' )
-	moose.connect( sh, 'activationOut', Ca_NMDA, 'activation' )
-	sh.numSynapses = 1
-	sh.synapse[0].weight = 1
+    sh = moose.SimpleSynHandler( Ca_NMDA.path + '/sh' )
+    moose.connect( sh, 'activationOut', Ca_NMDA, 'activation' )
+    sh.numSynapses = 1
+    sh.synapse[0].weight = 1
 
 
 
-        '''
-	if moose.exists( 'Ca_NMDA' ):
-		return
-	Ca_NMDA = moose.SynChan( 'Ca_NMDA' )
-	Ca_NMDA.Ek = ECA
-	Ca_NMDA.tau1 = 20.0e-3
-	Ca_NMDA.tau2 = 20.0e-3
-	Ca_NMDA.Gbar = 5 * SOMA_A
+    '''
+    if moose.exists( 'Ca_NMDA' ):
+        return
+    Ca_NMDA = moose.SynChan( 'Ca_NMDA' )
+    Ca_NMDA.Ek = ECA
+    Ca_NMDA.tau1 = 20.0e-3
+    Ca_NMDA.tau2 = 20.0e-3
+    Ca_NMDA.Gbar = 5 * SOMA_A
 
-	block = moose.MgBlock( '/library/Ca_NMDA/block' )
-	block.CMg = 1.2		#	[Mg] in mM
-	block.Zk = 2
-	block.KMg_A = 1.0/0.28
-	block.KMg_B = 1.0/62
+    block = moose.MgBlock( '/library/Ca_NMDA/block' )
+    block.CMg = 1.2        #    [Mg] in mM
+    block.Zk = 2
+    block.KMg_A = 1.0/0.28
+    block.KMg_B = 1.0/62
 
-	moose.connect( Ca_NMDA, 'channelOut', block, 'origChannel', 'OneToOne' )
-	addmsg1 = moose.Mstring( '/library/Ca_NMDA/addmsg1' )
-	addmsg1.value = '.. VmOut	./block	Vm'
-	addmsg2 = moose.Mstring( '/library/Ca_NMDA/addmsg2' )
-	addmsg2.value = './block	IkOut ../NMDA_Ca_conc current'
-	# The original model has the Ca current also coming here.
+    moose.connect( Ca_NMDA, 'channelOut', block, 'origChannel', 'OneToOne' )
+    addmsg1 = moose.Mstring( '/library/Ca_NMDA/addmsg1' )
+    addmsg1.value = '.. VmOut    ./block    Vm'
+    addmsg2 = moose.Mstring( '/library/Ca_NMDA/addmsg2' )
+    addmsg2.value = './block    IkOut ../NMDA_Ca_conc current'
+    # The original model has the Ca current also coming here.
 
-	sh = moose.SimpleSynHandler( 'Ca_NMDA/sh' )
-	moose.connect( sh, 'activationOut', Ca_NMDA, 'activation' )
-	sh.numSynapses = 1
-	sh.synapse[0].weight = 1
-        '''
+    sh = moose.SimpleSynHandler( 'Ca_NMDA/sh' )
+    moose.connect( sh, 'activationOut', Ca_NMDA, 'activation' )
+    sh.numSynapses = 1
+    sh.synapse[0].weight = 1
+    '''
 
 #=====================================================================
 #                        SPIKE DETECTOR
@@ -531,9 +530,9 @@ def make_Ca_NMDA( name ):
 
 #//addmsg axon/spike axon BUFFER name
 def make_axon( name ):
-	if moose.exists( '/library/' + name ):
-		return
-	axon = moose.SpikeGen( '/library/' + name )
-	axon.threshold = -40e-3 			#	V
-	axon.abs_refract = 10e-3			# 	sec
+    if moose.exists( '/library/' + name ):
+        return
+    axon = moose.SpikeGen( '/library/' + name )
+    axon.threshold = -40e-3             #    V
+    axon.abs_refract = 10e-3            #     sec
 


### PR DESCRIPTION
This PR makes all scripts python3 compatible. These scripts will not work with current stable version 3.1.4  and python3. 

To test this PR, you need pymoose >= 3.2.0 (in beta channel, to be moved to stable channel soon) which can be installed using `pip`.

    $ pip install pymoose --user --pre --upgrade 

Wheels are available for Linux/OSX. For other platform, you may have to build pymoose by yourself (see https://github.com/BhallaLab/moose-core/blob/master/INSTALL.md) 